### PR TITLE
fix(footer): update GitHub and Discord social links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -124,10 +124,10 @@ function SmallPrint() {
         <SocialLink href="#" icon={XIcon}>
           Follow us on X
         </SocialLink>
-        <SocialLink href="#" icon={GitHubIcon}>
+        <SocialLink href="https://github.com/AurelianSpodarec/LuaDocs" icon={GitHubIcon}>
           Follow us on GitHub
         </SocialLink>
-        <SocialLink href="#" icon={DiscordIcon}>
+        <SocialLink href="https://discord.gg/Jp2HFx3KTH" icon={DiscordIcon}>
           Join our Discord server
         </SocialLink>
       </div>


### PR DESCRIPTION
This PR updates the GitHub and Discord links in the Footer.tsx component:
The link were referenced from `src/app/docs/_components/Header.tsx`.
I did not find an X link, so its href remains set to "#".

